### PR TITLE
Feature 36: Add transparent button attribute

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -38,6 +38,10 @@ export namespace Components {
         "href": string | null;
         "isActive": boolean;
         "isDisabled": boolean;
+        /**
+          * Makes the button's background transparent. Buttons without this attribute are called *solid* in the swissgeol Figma.
+         */
+        "isTransparent": boolean;
         "justify": SgcButtonJustify;
         /**
           * Anchor `rel` attribute. Only has an effect when {@link href} is set.
@@ -54,7 +58,10 @@ export namespace Components {
     interface SgcCheckbox {
         "isDisabled": boolean;
         "isIndeterminate": boolean;
-        "value": boolean;
+        /**
+          * Whether the checkbox is on or off.  If this is `undefined`, the checkbox will keep track of the state internally. Otherwise, the use side is responsible for toggling this value.
+         */
+        "value"?: boolean;
     }
     interface SgcChecklist {
         "isDisabled": boolean;
@@ -334,6 +341,10 @@ declare namespace LocalJSX {
         "href"?: string | null;
         "isActive"?: boolean;
         "isDisabled"?: boolean;
+        /**
+          * Makes the button's background transparent. Buttons without this attribute are called *solid* in the swissgeol Figma.
+         */
+        "isTransparent"?: boolean;
         "justify"?: SgcButtonJustify;
         "onButtonClick"?: (event: SgcButtonCustomEvent<MouseEvent>) => void;
         /**
@@ -352,7 +363,10 @@ declare namespace LocalJSX {
         "isDisabled"?: boolean;
         "isIndeterminate"?: boolean;
         "onCheckboxChange"?: (event: SgcCheckboxCustomEvent<boolean>) => void;
-        "value": boolean;
+        /**
+          * Whether the checkbox is on or off.  If this is `undefined`, the checkbox will keep track of the state internally. Otherwise, the use side is responsible for toggling this value.
+         */
+        "value"?: boolean;
     }
     interface SgcChecklist {
         "isDisabled"?: boolean;

--- a/src/components/sgc-button/sgc-button.css
+++ b/src/components/sgc-button/sgc-button.css
@@ -139,28 +139,29 @@ a {
 :host([color="tertiary"]) {
   --button-text: var(--sgc-color-primary);
   --button-bg: var(--sgc-color-bg--white);
-  --button-border: var(--sgc-color-bg--white);
+  --button-border: var(--button-bg);
 
   --button-text--hovered: var(--sgc-color-text--emphasis-medium);
   --button-bg--hovered: var(--sgc-color-secondary--hovered);
-  --button-border--hovered: var(--sgc-color-secondary--hovered);
+  --button-border--hovered: var(--button-bg);
 
   --button-text--pressed: var(--sgc-color-text--emphasis-medium);
   --button-bg--pressed: var(--sgc-color-secondary--pressed);
-  --button-border--pressed: var(--sgc-color-secondary--pressed);
+  --button-border--pressed: var(--button-bg--pressed);
 
   --button-text--disabled: var(--sgc-color-bg--disabled);
   --button-bg--disabled: var(--sgc-color-secondary--disabled);
-  --button-border--disabled: var(--sgc-color-secondary--disabled);
+  --button-border--disabled: var(--button-bg--disabled);
 
   --button-text--active: var(--sgc-color-text--emphasis-medium);
   --button-bg--active: var(--sgc-color-secondary--active);
-  --button-border--active: var(--sgc-color-secondary--active);
+  --button-border--active: var(--button-bg--active);
 }
 
 /* transparent */
-:host([transparent]) {
+:host([transparent]:not([color="primary"])) {
   --button-bg: transparent;
+  --button-bg--disabled: transparent;
 }
 
 /* icon shape */

--- a/src/components/sgc-button/sgc-button.tsx
+++ b/src/components/sgc-button/sgc-button.tsx
@@ -28,6 +28,13 @@ export class SgcButton {
   isDisabled = false;
 
   /**
+   * Makes the button's background transparent.
+   * Buttons without this attribute are called *solid* in the swissgeol Figma.
+   */
+  @Prop({ reflect: true, attribute: 'transparent' })
+  isTransparent = false;
+
+  /**
    * Anchor `href` attribute.
    * When this is set, the button will use the `a` tag instead of `button`.
    *

--- a/src/components/sgc-checkbox/sgc-checkbox.tsx
+++ b/src/components/sgc-checkbox/sgc-checkbox.tsx
@@ -7,6 +7,7 @@ import {
   Host,
   Listen,
   Prop,
+  State,
   Watch,
 } from '@stencil/core';
 import styles from './sgc-checkbox.css';
@@ -19,7 +20,7 @@ import styles from './sgc-checkbox.css';
 })
 export class SgcCheckbox {
   @Prop()
-  value!: boolean;
+  value?: boolean;
 
   @Prop({ reflect: true, attribute: 'indeterminate' })
   isIndeterminate = false;
@@ -33,29 +34,44 @@ export class SgcCheckbox {
   @AttachInternals()
   internals!: ElementInternals;
 
+  @State()
+  private internalValue = false;
+
   connectedCallback(): void {
     this.handleValueChange();
   }
 
   @Watch('value')
   handleValueChange(): void {
-    this.internals?.setFormValue(this.value ? 'on' : null);
+    this.internalValue = this.value ?? false;
+    this.updateFormValue();
+  }
+
+  private updateFormValue(): void {
+    this.internals?.setFormValue(this.internalValue ? 'on' : null);
   }
 
   @Listen('click')
   handleClick(e: MouseEvent): void {
     e.preventDefault();
     e.stopPropagation();
-    this.changeEvent.emit(!this.value);
+
+    if (this.value === undefined) {
+      this.internalValue = !this.internalValue;
+      this.updateFormValue();
+      this.changeEvent.emit(this.internalValue);
+    } else {
+      this.changeEvent.emit(!this.value);
+    }
   }
 
   render = () => (
     <Host
       role="checkbox"
       tabindex="0"
-      aria-checked={this.value.toString()}
+      aria-checked={this.internalValue.toString()}
       class={{
-        'is-checked': this.value,
+        'is-checked': this.internalValue,
         'is-indeterminate': this.isIndeterminate,
       }}
     >

--- a/src/components/sgc-checkbox/sgc-checkbox.tsx
+++ b/src/components/sgc-checkbox/sgc-checkbox.tsx
@@ -19,6 +19,12 @@ import styles from './sgc-checkbox.css';
   formAssociated: true,
 })
 export class SgcCheckbox {
+  /**
+   * Whether the checkbox is on or off.
+   *
+   * If this is `undefined`, the checkbox will keep track of the state internally.
+   * Otherwise, the use side is responsible for toggling this value.
+   */
   @Prop()
   value?: boolean;
 

--- a/src/examples/button.html
+++ b/src/examples/button.html
@@ -21,6 +21,15 @@
       gap: 2rem;
     "
   >
+    <h1>Buttons</h1>
+
+    <div>
+      <label>
+        <sgc-checkbox id="transparency-toggle"></sgc-checkbox>
+        <span>Transparent?</span>
+      </label>
+    </div>
+
     <div
       style="
         display: grid;
@@ -188,4 +197,29 @@
       </div>
     </section>
   </body>
+  <script>
+    document
+      .getElementById("transparency-toggle")
+      .addEventListener("checkboxChange", (event) => {
+        document.querySelectorAll("sgc-button").forEach((button) => {
+          button.isTransparent = event.detail;
+        });
+      });
+  </script>
+  <style>
+    h1 {
+      margin-bottom: 0;
+    }
+
+    body {
+      background-color: #f7f7f7;
+    }
+
+    label {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      cursor: pointer;
+    }
+  </style>
 </html>


### PR DESCRIPTION
Resolves #36.

Adds the `isTransparent` property to `sgc-button` with which its background color can be set to `transparent`. Note that `color="primary"` does not support this attribute.

This PR also contains a change to `sgc-checkbox` so that that component can be used without having to manually control its state.