### PR TITLE
Rename icon to match Figma

### DIFF
--- a/src/components/sgc-icon/icons/cross.svg.ts
+++ b/src/components/sgc-icon/icons/cross.svg.ts
@@ -1,4 +1,4 @@
-export const closeSvg = `
+export const crossSvg = `
   <svg width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
   <path d="M4.20996 16.2898L16.7897 3.71009M16.7897 16.2898L4.21002 3.71008" stroke="#337083" stroke-width="1.4" stroke-linecap="round"/>
   </svg>

--- a/src/components/sgc-icon/sgc-icon.tsx
+++ b/src/components/sgc-icon/sgc-icon.tsx
@@ -1,7 +1,7 @@
 import { Component, h, Host, Prop } from '@stencil/core';
 import styles from './sgc-icon.css';
 import { plusSvg } from './icons/plus.svg';
-import { closeSvg } from './icons/check.svg';
+import { crossSvg } from './icons/cross.svg';
 import { checkmarkSvg } from './icons/checkmark.svg';
 import { assignSvg } from './icons/assign.svg';
 import { editSvg } from './icons/edit.svg';
@@ -30,7 +30,7 @@ export class SgcIcon {
 
 const icons = {
   assign: assignSvg,
-  close: closeSvg,
+  cross: crossSvg,
   checkmark: checkmarkSvg,
   chevronRight: chevronRightSvg,
   edit: editSvg,

--- a/src/components/sgc-workflow/sgc-workflow-step/sgc-workflow-step.tsx
+++ b/src/components/sgc-workflow/sgc-workflow-step/sgc-workflow-step.tsx
@@ -86,7 +86,7 @@ export class SgcWorkflowStep {
       return <sgc-icon name="checkmark"></sgc-icon>;
     }
     if (this.status === WorkflowStatus.Published) {
-      return <sgc-icon name="close"></sgc-icon>;
+      return <sgc-icon name="cross"></sgc-icon>;
     }
     return `${this.index + 1}`;
   }

--- a/src/components/sgc-workflow/sgc-workflow-steps/sgc-workflow-steps.tsx
+++ b/src/components/sgc-workflow/sgc-workflow-steps/sgc-workflow-steps.tsx
@@ -60,7 +60,7 @@ export class SgcWorkflowSteps {
         </sgc-button>,
         <sgc-button color="secondary">
           <sgc-translate ns="workflow">actions.requestChanges</sgc-translate>
-          <sgc-icon name="close"></sgc-icon>
+          <sgc-icon name="cross"></sgc-icon>
         </sgc-button>,
       ]}
       {this.workflow.status === WorkflowStatus.Draft && (


### PR DESCRIPTION
The file name did not match the icon name (`check` instead of `close`). For this icon, I find `cross` (analogous to Figma) just as suitable as `close`, which is why I have also adapted the icon name.