### PR TITLE
Feature 50: Publish packages to npmjs

### DIFF
--- a/.github/scripts/package.config.mjs
+++ b/.github/scripts/package.config.mjs
@@ -1,7 +1,5 @@
 export const packages = {
-  core: 'ghcr.io/swisstopo/swissgeol-ui-core',
-  angular: 'ghcr.io/swisstopo/swissgeol-ui-core-angular',
-  react: 'ghcr.io/swisstopo/swissgeol-ui-core-react',
+  core: '@swissgeol/ui-core',
+  angular: '@swissgeol/ui-core-angular',
+  react: '@swissgeol/ui-core-react',
 };
-
-export const packageType = 'npm';

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://npm.pkg.github.com/"
+          registry-url: "https://registry.npmjs.org/"
       - name: Cache node dependencies
         uses: ./.github/actions/node-cache
       - name: Install node dependencies
@@ -107,7 +107,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://npm.pkg.github.com/"
+          registry-url: "https://registry.npmjs.org/"
       - name: Restore cached node dependencies
         uses: ./.github/actions/node-cache-restore
       - name: Write package version
@@ -118,12 +118,25 @@ jobs:
       - name: Build
         run: npm run build
       - name: Publish
-        run: |
-          npm publish --tag ${{ needs.determine-version.outputs.tag }}
-          cd packages/angular/dist/swissgeol-core-angular && npm publish --tag ${{ needs.determine-version.outputs.tag }} && cd ../../../..
-          cd packages/react   && npm publish --tag ${{ needs.determine-version.outputs.tag }} && cd ../..
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN  }}
+        run: |
+          # Publish `@swissgeol/ui-core`
+          npm publish \
+            --tag ${{ needs.determine-version.outputs.tag }} \
+            --provenance
+
+          # Publish `@swissgeol/ui-core-angular`
+          cd packages/angular/dist/swissgeol-core-angular
+          npm publish \
+            --tag ${{ needs.determine-version.outputs.tag }} \
+            --provenance
+
+          # Publish `@swissgeol/ui-core-react`
+          cd ../../../../packages/react
+          npm publish \
+            --tag ${{ needs.determine-version.outputs.tag }} \
+            --provenance
 
   tag-commit:
     name: "tag commit"
@@ -145,30 +158,3 @@ jobs:
         with:
           TAG_NAME: ${{ needs.determine-version.outputs.version }}
           SHA: ${{ github.sha }}
-
-  cleanup:
-    name: "cleanup"
-    if: ${{ github.ref_name == 'main' }}
-    needs:
-      - determine-version
-      - tag-commit
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Setup node
-        run: |
-          npm install @octokit/rest
-      - name: Remove outdated versions
-        uses: actions/github-script@v7
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CURRENT_VERSION: ${{ needs.determine-version.outputs.version }}
-        with:
-          script: |
-            const { findOutdatedVersions, removePackageVersions } = await import('${{ github.workspace }}/.github/scripts/package.utils.mjs');
-            const { parseVersion, stringifyVersion } = await import('${{ github.workspace }}/.github/scripts/version.utils.mjs');
-
-            const version = parseVersion(process.env.CURRENT_VERSION);
-            const outdatedVersions = await findOutdatedVersions(version);
-            await removePackageVersions(outdatedVersions);

--- a/README.md
+++ b/README.md
@@ -9,19 +9,7 @@ but also generates wrappers for [Angular](https://angular.dev/) and [React](http
 
 ## Getting Started
 
-The library's npm packages are hosted in swisstopo's [GitHub registry](https://github.com/orgs/swisstopo/packages?ecosystem=npm).
-These packages are publicly available, but GitHub still enforces the need for an authentication token to be present when downloading them.
-To configure this token, first head to your [person access tokens](https://github.com/settings/tokens) and generate a _classic_ token with `read:packages` permissions.
-Afterward, at the following to the `.npmrc` file in your home or project directory:
-
-```
-@swisstopo:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken={your-github-token}
-```
-
-> You may also set `{your-github-token}` with an environment variable like `${GITHUB_TOKEN}`.
-
-You can now proceed to any of the following sections depending on how you want to use the library:
+Select the guide that reflects your application's setup:
 
 - [Getting Started: Web Components](#getting-started-web-components) if you want to use plain web components.
 - [Getting Started: Angular](#getting-started-angular) if you want to use the Angular wrappers.
@@ -34,20 +22,20 @@ Afterward, make sure to have a look at [Styling](#styling) and [Internationaliza
 To use swissgeol UI Core with plain web components, simply install the core library:
 
 ```bash
-npm install @swisstopo/swissgeol-ui-core
+npm install @swissgeol/ui-core
 ```
 
-Then, make sure to include the CSS at `@swisstopo/swissgeol-ui-core/styles.css` into your build process.
+Then, make sure to include the CSS at `@swissgeol/ui-core/styles.css` into your build process.
 
 Also, the library expects the Inter font to be served at `/assets/fonts/`.
-You can find all required font files at `@swisstopo/swissgeol-ui-core/dist/swissgeol-ui-core/assets/fonts/`.
+You can find all required font files at `@swissgeol/ui-core/dist/swissgeol-ui-core/assets/fonts/`.
 You can simply copy these assets into your build folder, for example with [Vite](https://vite.dev/):
 
 ```js
 viteStaticCopy({
   targets: [
     {
-      src: "node_modules/@swisstopo/swissgeol-ui-core/dist/swissgeol-ui-core/assets/*",
+      src: "node_modules/@swissgeol/ui-core/dist/swissgeol-ui-core/assets/*",
       dest: "assets",
     },
   ],
@@ -57,7 +45,7 @@ viteStaticCopy({
 At startup, you will have to import the library:
 
 ```js
-import "@swisstopo/swissgeol-ui-core/import";
+import "@swissgeol/ui-core/import";
 ```
 
 You can now use the web components in HTML.
@@ -67,8 +55,8 @@ You can now use the web components in HTML.
 To use swissgeol UI Core with Angular, install the core library and Angular extension:
 
 ```bash
-npm install @swisstopo/swissgeol-ui-core
-npm install @swisstopo/swissgeol-ui-core-angular
+npm install @swissgeol/ui-core
+npm install @swissgeol/ui-core-angular
 ```
 
 First, add the library's CSS and fonts to your build:
@@ -81,12 +69,12 @@ First, add the library's CSS and fonts to your build:
         "assets": [
           {
             "glob": "**/*",
-            "input": "node_modules/@swisstopo/swissgeol-ui-core/dist/swissgeol-ui-core/assets/fonts",
+            "input": "node_modules/@swissgeol/ui-core/dist/swissgeol-ui-core/assets/fonts",
             "output": "/assets/fonts"
           }
         ],
         "styles": [
-          "node_modules/@swisstopo/swissgeol-ui-core/dist/swissgeol-ui-core/swissgeol-ui-core.css"
+          "node_modules/@swissgeol/ui-core/dist/swissgeol-ui-core/swissgeol-ui-core.css"
         ]
       }
     }
@@ -118,33 +106,33 @@ export class AppModule {}
 To use swissgeol UI Core with React, install the core library and React extension:
 
 ```bash
-npm install @swisstopo/swissgeol-ui-core
-npm install @swisstopo/swissgeol-ui-core-react
+npm install @swissgeol/ui-core
+npm install @swissgeol/ui-core-react
 ```
 
-Then, make sure to include the CSS at `@swisstopo/swissgeol-ui-core/styles.css` into your build process.
+Then, make sure to include the CSS at `@swissgeol/ui-core/styles.css` into your build process.
 You may simply import them in your code if your bundlers supports that:
 
 ```js
-import "@swisstopo/swissgeol-ui-core/styles.css";
+import "@swissgeol/ui-core/styles.css";
 ```
 
 Also, the library expects the Inter font to be served at `/assets/fonts/`.
-You can find all required font files at `@swisstopo/swissgeol-ui-core/dist/swissgeol-ui-core/assets/fonts/`.
+You can find all required font files at `@swissgeol/ui-core/dist/swissgeol-ui-core/assets/fonts/`.
 You can simply copy these assets into your build folder, for example with [Vite](https://vite.dev/):
 
 ```js
 viteStaticCopy({
   targets: [
     {
-      src: "node_modules/@swisstopo/swissgeol-ui-core/dist/swissgeol-ui-core/assets/*",
+      src: "node_modules/@swissgeol/ui-core/dist/swissgeol-ui-core/assets/*",
       dest: "assets",
     },
   ],
 });
 ```
 
-You can now use the JSX components by importing from `@swisstopo/swissgeol-ui-core-react`.
+You can now use the JSX components by importing from `@swissgeol/ui-core-react`.
 
 > The type checking for the wrapper components is as-of-yet very rudimentary,
 > so you have to manually ensure that you conform to the library's interface.
@@ -191,7 +179,7 @@ However, you will probably want to synchronize the library's translation languag
 To do so, you can use the `SwissgeolCoreI18n` object:
 
 ```js
-import { SwissgeolCoreI18n, Language } from "@swisstopo/swissgeol-ui-core";
+import { SwissgeolCoreI18n, Language } from "@swissgeol/ui-core";
 
 SwissgeolCoreI18n.setLanguage(Language.German);
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@swisstopo/swissgeol-ui-core",
+  "name": "@swissgeol/ui-core",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "peer": true,
   "packages": {
     "": {
-      "name": "@swisstopo/swissgeol-ui-core",
+      "name": "@swissgeol/ui-core",
       "version": "0.0.0",
       "license": "MIT",
       "workspaces": [
@@ -550,9 +550,9 @@
       }
     },
     "node_modules/@angular/cli/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1150,6 +1150,7 @@
       "integrity": "sha512-b2cG41r6lilApXLlvja1Ra2D00dM3BxmQhoElKC1tOnpD6S3/krlH1DOnBB2I55RBn9iv4zdmPz1l8zPUSh7DQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.26.9",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -1179,6 +1180,7 @@
       "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -1209,7 +1211,8 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@angular/compiler-cli/node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
@@ -1217,6 +1220,7 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -1226,7 +1230,8 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@angular/compiler-cli/node_modules/semver": {
       "version": "7.7.1",
@@ -1234,6 +1239,7 @@
       "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -7106,9 +7112,9 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7170,15 +7176,15 @@
         "node": ">=10"
       }
     },
-    "node_modules/@swisstopo/swissgeol-ui-core": {
+    "node_modules/@swissgeol/ui-core": {
       "resolved": "",
       "link": true
     },
-    "node_modules/@swisstopo/swissgeol-ui-core-angular": {
+    "node_modules/@swissgeol/ui-core-angular": {
       "resolved": "packages/angular",
       "link": true
     },
-    "node_modules/@swisstopo/swissgeol-ui-core-react": {
+    "node_modules/@swissgeol/ui-core-react": {
       "resolved": "packages/react",
       "link": true
     },
@@ -7202,9 +7208,9 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -7916,9 +7922,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8256,9 +8262,9 @@
       }
     },
     "node_modules/@vue/language-core/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9414,9 +9420,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21612,9 +21618,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-      "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
+      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -24130,7 +24136,7 @@
       }
     },
     "packages/angular": {
-      "name": "@swisstopo/swissgeol-ui-core-angular",
+      "name": "@swissgeol/ui-core-angular",
       "version": "0.0.0",
       "dependencies": {
         "zone.js": "~0.15.0"
@@ -24149,7 +24155,7 @@
         "@angular/core": "19.2.2",
         "@angular/forms": "19.2.2",
         "@angular/router": "19.2.2",
-        "@swisstopo/swissgeol-ui-core": "*",
+        "@swissgeol/ui-core": "*",
         "rxjs": "~7.8.0",
         "zone.js": "~0.15.0"
       }
@@ -24164,8 +24170,8 @@
         "@angular/platform-browser": "^19.2.0",
         "@angular/platform-browser-dynamic": "^19.2.8",
         "@angular/router": "^19.2.0",
-        "@swisstopo/swissgeol-ui-core": "*",
-        "@swisstopo/swissgeol-ui-core-angular": "*",
+        "@swissgeol/ui-core": "*",
+        "@swissgeol/ui-core-angular": "*",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -24571,6 +24577,90 @@
       "engines": {
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       }
+    },
+    "packages/angular-client/node_modules/@angular/compiler-cli": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.2.14.tgz",
+      "integrity": "sha512-e9/h86ETjoIK2yTLE9aUeMCKujdg/du2pq7run/aINjop4RtnNOw+ZlSTUa6R65lP5CVwDup1kPytpAoifw8cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "7.26.9",
+        "@jridgewell/sourcemap-codec": "^1.4.14",
+        "chokidar": "^4.0.0",
+        "convert-source-map": "^1.5.1",
+        "reflect-metadata": "^0.2.0",
+        "semver": "^7.0.0",
+        "tslib": "^2.3.0",
+        "yargs": "^17.2.1"
+      },
+      "bin": {
+        "ng-xi18n": "bundles/src/bin/ng_xi18n.js",
+        "ngc": "bundles/src/bin/ngc.js",
+        "ngcc": "bundles/ngcc/index.js"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "@angular/compiler": "19.2.14",
+        "typescript": ">=5.5 <5.9"
+      }
+    },
+    "packages/angular-client/node_modules/@angular/compiler-cli/node_modules/@babel/core": {
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.9.tgz",
+      "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.9",
+        "@babel/helper-compilation-targets": "^7.26.5",
+        "@babel/helper-module-transforms": "^7.26.0",
+        "@babel/helpers": "^7.26.9",
+        "@babel/parser": "^7.26.9",
+        "@babel/template": "^7.26.9",
+        "@babel/traverse": "^7.26.9",
+        "@babel/types": "^7.26.9",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "packages/angular-client/node_modules/@angular/compiler-cli/node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/angular-client/node_modules/@angular/compiler-cli/node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "packages/angular-client/node_modules/@angular/compiler-cli/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/angular-client/node_modules/@angular/core": {
       "version": "19.2.8",
@@ -25363,11 +25453,11 @@
       }
     },
     "packages/react": {
-      "name": "@swisstopo/swissgeol-ui-core-react",
+      "name": "@swissgeol/ui-core-react",
       "version": "0.0.0",
       "devDependencies": {
         "@babel/preset-react": "^7.26.3",
-        "@swisstopo/swissgeol-ui-core": "*",
+        "@swissgeol/ui-core": "*",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",
@@ -25380,7 +25470,7 @@
       },
       "peerDependencies": {
         "@stencil/react-output-target": "^1.0.2",
-        "@swisstopo/swissgeol-ui-core": "*",
+        "@swissgeol/ui-core": "*",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
@@ -25388,8 +25478,8 @@
     "packages/react-client": {
       "version": "0.0.0",
       "dependencies": {
-        "@swisstopo/swissgeol-ui-core": "*",
-        "@swisstopo/swissgeol-ui-core-react": "*",
+        "@swissgeol/ui-core": "*",
+        "@swissgeol/ui-core-react": "*",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -25407,7 +25497,7 @@
     "packages/wc-client": {
       "version": "0.0.0",
       "dependencies": {
-        "@swisstopo/swissgeol-ui-core": "*",
+        "@swissgeol/ui-core": "*",
         "lit": "^3.3.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
-  "name": "@swisstopo/swissgeol-ui-core",
+  "name": "@swissgeol/ui-core",
   "version": "0.0.0",
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
-  },
   "description": "swissgeol UI Core Library",
   "workspaces": [
     ".",
@@ -30,12 +27,15 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "prepare": "husky"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
   "types": "dist/types/index.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
-  "unpkg": "dist/swissgeol-ui-core/swissgeol-ui-core.esm.js",
+  "unpkg": "dist/ui-core/ui-core.esm.js",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",

--- a/packages/angular-client/README.md
+++ b/packages/angular-client/README.md
@@ -8,7 +8,7 @@
   ```json
   {
     "glob": "**/*",
-    "input": "node_modules/swissgeol-core/assets/fonts",
+    "input": "node_modules/@swissgeol/ui-core/assets/fonts",
     "output": "/assets/fonts"
   }
   ```

--- a/packages/angular-client/angular.json
+++ b/packages/angular-client/angular.json
@@ -25,12 +25,12 @@
               },
               {
                 "glob": "**/*",
-                "input": "node_modules/@swisstopo/swissgeol-ui-core/dist/swissgeol-ui-core/assets/fonts",
+                "input": "node_modules/@swissgeol/ui-core/dist/swissgeol-ui-core/assets/fonts",
                 "output": "assets/fonts"
               }
             ],
             "styles": [
-              "node_modules/@swisstopo/swissgeol-ui-core/dist/swissgeol-ui-core/swissgeol-ui-core.css",
+              "node_modules/@swissgeol/ui-core/dist/swissgeol-ui-core/swissgeol-ui-core.css",
               "src/styles.css"
             ]
           },

--- a/packages/angular-client/package.json
+++ b/packages/angular-client/package.json
@@ -18,8 +18,8 @@
     "@angular/platform-browser-dynamic": "^19.2.8",
     "@angular/router": "^19.2.0",
     "rxjs": "~7.8.0",
-    "@swisstopo/swissgeol-ui-core": "*",
-    "@swisstopo/swissgeol-ui-core-angular": "*",
+    "@swissgeol/ui-core": "*",
+    "@swissgeol/ui-core-angular": "*",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"
   },

--- a/packages/angular-client/src/app/app.module.ts
+++ b/packages/angular-client/src/app/app.module.ts
@@ -2,7 +2,7 @@ import { AppComponent } from './app.component';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BrowserModule } from '@angular/platform-browser';
-import { SwissgeolCoreModule } from '@swisstopo/swissgeol-ui-core-angular';
+import { SwissgeolCoreModule } from '@swissgeol/ui-core-angular';
 
 @NgModule({
   declarations: [AppComponent],

--- a/packages/angular-client/src/main.ts
+++ b/packages/angular-client/src/main.ts
@@ -1,6 +1,6 @@
 import { AppModule } from './app/app.module';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-import { Language, SwissgeolCoreI18n } from '@swisstopo/swissgeol-ui-core';
+import { Language, SwissgeolCoreI18n } from '@swissgeol/ui-core';
 
 SwissgeolCoreI18n.setLanguage(Language.German);
 

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,9 +1,6 @@
 {
-  "name": "@swisstopo/swissgeol-ui-core-angular",
+  "name": "@swissgeol/ui-core-angular",
   "version": "0.0.0",
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
-  },
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -12,6 +9,13 @@
     "build:share": "tsx scripts/share-build.ts",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/swisstopo/swissgeol-ui-core.git"
   },
   "files": [
     "package.json",
@@ -44,7 +48,7 @@
     "@angular/forms": "19.2.2",
     "@angular/router": "19.2.2",
     "rxjs": "~7.8.0",
-    "@swisstopo/swissgeol-ui-core": "*",
+    "@swissgeol/ui-core": "*",
     "zone.js": "~0.15.0"
   }
 }

--- a/packages/angular/projects/swissgeol-core-angular/src/lib/swissgeol-core.module.ts
+++ b/packages/angular/projects/swissgeol-core-angular/src/lib/swissgeol-core.module.ts
@@ -1,5 +1,5 @@
 import { NgModule, provideAppInitializer } from '@angular/core';
-import { defineCustomElements } from '@swisstopo/swissgeol-ui-core/loader';
+import { defineCustomElements } from '@swissgeol/ui-core/loader';
 import { DIRECTIVES } from './stencil-generated';
 
 @NgModule({

--- a/packages/angular/scripts/share-build.ts
+++ b/packages/angular/scripts/share-build.ts
@@ -15,7 +15,7 @@ linkCore(clientDir);
 
 const targetDir = path.join(
   clientDir,
-  'node_modules/@swisstopo/swissgeol-ui-core-angular',
+  'node_modules/@swissgeol/ui-core-angular',
 );
 fs.rmSync(targetDir, { recursive: true, force: true });
 

--- a/packages/react-client/package.json
+++ b/packages/react-client/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "@swisstopo/swissgeol-ui-core": "*",
-    "@swisstopo/swissgeol-ui-core-react": "*"
+    "@swissgeol/ui-core": "*",
+    "@swissgeol/ui-core-react": "*"
   }
 }

--- a/packages/react-client/src/app/app.tsx
+++ b/packages/react-client/src/app/app.tsx
@@ -1,11 +1,7 @@
 // Uncomment this line to use CSS modules
 // import styles from './app.module.scss';
 
-import {
-  SgcButton,
-  SgcIcon,
-  SgcMenuItem,
-} from '@swisstopo/swissgeol-ui-core-react';
+import { SgcButton, SgcIcon, SgcMenuItem } from '@swissgeol/ui-core-react';
 import styles from './app.module.scss';
 
 export function App() {

--- a/packages/react-client/src/styles.scss
+++ b/packages/react-client/src/styles.scss
@@ -1,1 +1,1 @@
-@import "@swisstopo/swissgeol-ui-core/styles.css";
+@import "@swissgeol/ui-core/styles.css";

--- a/packages/react-client/vite.config.ts
+++ b/packages/react-client/vite.config.ts
@@ -20,7 +20,7 @@ export default defineConfig(() => ({
     viteStaticCopy({
       targets: [
         {
-          src: 'node_modules/@swisstopo/swissgeol-ui-core/dist/swissgeol-ui-core/assets/*',
+          src: 'node_modules/@swissgeol/ui-core/dist/swissgeol-ui-core/assets/*',
           dest: 'assets',
         },
       ],

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,9 +1,6 @@
 {
-  "name": "@swisstopo/swissgeol-ui-core-react",
+  "name": "@swissgeol/ui-core-react",
   "version": "0.0.0",
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
-  },
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -12,6 +9,9 @@
     "build": "npm run build:prepare && vite build && npm run build:share",
     "build:prepare": "tsx scripts/prepare-build.ts",
     "build:share": "tsx scripts/share-build.ts"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "exports": {
     "./package.json": "./package.json",
@@ -25,6 +25,10 @@
     "package.json",
     "dist"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/swisstopo/swissgeol-ui-core.git"
+  },
   "devDependencies": {
     "@babel/preset-react": "^7.26.3",
     "@types/react": "^19.1.2",
@@ -36,11 +40,11 @@
     "vitest": "^3.1.2",
     "@vitejs/plugin-react": "^4.4.1",
     "typescript": "5.8.3",
-    "@swisstopo/swissgeol-ui-core": "*"
+    "@swissgeol/ui-core": "*"
   },
   "peerDependencies": {
     "@stencil/react-output-target": "^1.0.2",
-    "@swisstopo/swissgeol-ui-core": "*",
+    "@swissgeol/ui-core": "*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   }

--- a/packages/react/scripts/prepare-build.ts
+++ b/packages/react/scripts/prepare-build.ts
@@ -12,8 +12,8 @@ replaceInFile(
   ),
   [
     [
-      'from "@swisstopo/swissgeol-ui-core/dist/components/',
-      'from "@swisstopo/swissgeol-ui-core/components/',
+      'from "@swissgeol/ui-core/dist/components/',
+      'from "@swissgeol/ui-core/components/',
     ],
   ],
 );

--- a/packages/react/scripts/share-build.ts
+++ b/packages/react/scripts/share-build.ts
@@ -11,10 +11,7 @@ const clientDir = resolveInProject('packages/react-client');
 // Copy core package into `react-client`.
 linkCore(clientDir);
 
-const targetDir = path.join(
-  clientDir,
-  'node_modules/@swisstopo/swissgeol-ui-core-react',
-);
+const targetDir = path.join(clientDir, 'node_modules/@swissgeol/ui-core-react');
 fs.rmSync(targetDir, { recursive: true, force: true });
 
 copyRecursive(

--- a/packages/wc-client/package.json
+++ b/packages/wc-client/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "lit": "^3.3.0",
-    "@swisstopo/swissgeol-ui-core": "*"
+    "@swissgeol/ui-core": "*"
   },
   "devDependencies": {
     "vite": "^6.3.5",

--- a/packages/wc-client/src/index.css
+++ b/packages/wc-client/src/index.css
@@ -1,1 +1,1 @@
-@import "@swisstopo/swissgeol-ui-core/styles.css";
+@import "@swissgeol/ui-core/styles.css";

--- a/packages/wc-client/src/my-element.ts
+++ b/packages/wc-client/src/my-element.ts
@@ -1,5 +1,5 @@
 import { LitElement, html } from 'lit';
-import '@swisstopo/swissgeol-ui-core/import';
+import '@swissgeol/ui-core/import';
 import { customElement } from 'lit/decorators.js';
 
 @customElement('my-element')

--- a/packages/wc-client/vite.config.ts
+++ b/packages/wc-client/vite.config.ts
@@ -6,11 +6,11 @@ export default defineConfig({
     viteStaticCopy({
       targets: [
         {
-          src: './node_modules/@swisstopo/swissgeol-ui-core/dist/swissgeol-ui-core/assets/*',
+          src: './node_modules/@swissgeol/ui-core/dist/swissgeol-ui-core/assets/*',
           dest: 'assets',
         },
         {
-          src: './node_modules/@swisstopo/swissgeol-ui-core/dist/swissgeol-ui-core/assets/*',
+          src: './node_modules/@swissgeol/ui-core/dist/swissgeol-ui-core/assets/*',
           dest: 'assets',
         },
       ],

--- a/scripts/project.utils.ts
+++ b/scripts/project.utils.ts
@@ -12,10 +12,7 @@ export const resolveInProject = (...parts: string[]): string =>
   path.join(PROJECT_ROOT_DIR, ...parts);
 
 export const linkCore = (target: string): void => {
-  const targetDir = path.join(
-    target,
-    'node_modules/@swisstopo/swissgeol-ui-core',
-  );
+  const targetDir = path.join(target, 'node_modules/@swissgeol/ui-core');
   fs.rmSync(targetDir, { recursive: true, force: true });
   copyRecursive(resolveInProject('dist'), path.join(targetDir, 'dist'));
   copyRecursive(resolveInProject('loader'), path.join(targetDir, 'loader'));

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -34,7 +34,7 @@ export const config: Config = {
       ],
     },
     angularOutputTarget({
-      componentCorePackage: '@swisstopo/swissgeol-ui-core',
+      componentCorePackage: '@swissgeol/ui-core',
       outputType: 'component',
       directivesProxyFile:
         'packages/angular/projects/swissgeol-core-angular/src/lib/stencil-generated/components.ts',


### PR DESCRIPTION
Resolves #50.

Changes the `publish` workflow to target npm.js rather than GitHub Registry.

Note that due to NPM's policies, it is rather difficult to remove packages once published. I opted to just forego this, meaning any dev packages will remain published. This is not an issue to me, and quite common among JS packages.

During development, I already published a couple versions: https://www.npmjs.com/package/@swissgeol/ui-core
Once this PR is merged to `main`, a new v1.0.0 will become available.