### PR TITLE
Bugfix/assets 605: Bug: Workflows: Modal zu Button "Status manuell ändern" passt sich nicht dem Stand im Workflow an

### DIFF
--- a/src/components/sgc-workflow/sgc-workflow-steps/sgc-workflow-steps.tsx
+++ b/src/components/sgc-workflow/sgc-workflow-steps/sgc-workflow-steps.tsx
@@ -28,6 +28,12 @@ export class SgcWorkflowSteps {
   @Event({ eventName: 'sgcOpenFinishReviewDialog', composed: true })
   openFinishReviewDialogEvent: EventEmitter<void>;
 
+  private get shouldShowChangeStatusButton(): boolean {
+    return (
+      this.canChangeStatus && this.workflow.status !== WorkflowStatus.Draft
+    );
+  }
+
   render() {
     return (
       <Host>
@@ -63,7 +69,7 @@ export class SgcWorkflowSteps {
 
   private readonly renderActions = () => (
     <div class="actions">
-      {this.canChangeStatus && (
+      {this.shouldShowChangeStatusButton && (
         <sgc-button
           color="secondary"
           onButtonClick={() => this.openChangeStatusDialogEvent.emit()}


### PR DESCRIPTION
Resolves https://github.com/swisstopo/swissgeol-assets-suite/issues/605.

The second feature request, where statuses above the current one are hidden, is already implemented (I assume by @TIL-EBP), but that library version is probably not yet in use.