### PR TITLE
Bugfix/assets 605: Bug: Workflows: Modal zu Button "Status manuell ändern" passt sich nicht dem Stand im Workflow an

### DIFF
--- a/src/components/sgc-workflow/modals/sgc-change-status-dialog/sgc-change-status-dialog.tsx
+++ b/src/components/sgc-workflow/modals/sgc-change-status-dialog/sgc-change-status-dialog.tsx
@@ -73,7 +73,7 @@ export class SgcChangeStatusDialog {
       }))
       .filter(
         (status) =>
-          getRoleIndex(getRoleForStatus(status.key)) <=
+          getRoleIndex(getRoleForStatus(status.key)) <
             getRoleIndex(getRoleForStatus(this.workflow.status)) &&
           status.key !== WorkflowStatus.Published,
       );


### PR DESCRIPTION
Resolves https://github.com/swisstopo/swissgeol-assets-suite/issues/605.