### PR TITLE
Feature 77: Align workflow checkboxes with actual backing data

### DIFF
--- a/src/components/sgc-workflow/sgc-workflow-selection/sgc-workflow-selection.tsx
+++ b/src/components/sgc-workflow/sgc-workflow-selection/sgc-workflow-selection.tsx
@@ -100,7 +100,10 @@ export class SgcWorkflowSelection {
   );
 
   private readonly renderGroup = (group: SgcWorkflowSelectionGroup<string>) => (
-    <sgc-checklist name={group.name()} isDisabled={this.isFullyDisabled}>
+    <sgc-checklist
+      name={group.name()}
+      isDisabled={this.isFullyDisabled || group.isDisabled}
+    >
       {group.fields.map(this.renderField)}
     </sgc-checklist>
   );
@@ -135,6 +138,7 @@ export type SgcWorkflowSelectionEntry<TField extends string> =
 
 export interface SgcWorkflowSelectionGroup<TField extends string> {
   name: () => string;
+  isDisabled?: boolean;
   fields: Array<SgcWorkflowSelectionField<TField>>;
 }
 


### PR DESCRIPTION
Resolves #77.

Adds a new `isDisabled` field to `SgcWorkflowSelectionGroup` which allows to procedurally disable specific workflow selection tabs.

Note that the selection tabs are not defined by this library, but have to be defined by the downstream consumers. This means that the actual state of whether a specific selection tab has any data or not has to be supplied by the applications themselves.